### PR TITLE
Use plain text password

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -64,11 +64,7 @@ func ConnectToKeyServer(caFile, certFile, keyFile, keyServer string) (client *ke
 	}
 	password = sys.InputPassword(true, "", "Enter key server's password (no echo)")
 	fmt.Fprintf(os.Stderr, "Establishing connection to %s on port %d...\n", serverAddr, port)
-	salt, err := client.GetSalt()
-	if err != nil {
-		return nil, "", err
-	}
-	if err := client.Ping(keyserv.PingRequest{Password: keyserv.HashPassword(salt, password)}); err != nil {
+	if err := client.Ping(keyserv.PingRequest{PlainPassword: password}); err != nil {
 		return nil, "", err
 	}
 	return
@@ -516,11 +512,7 @@ func SendCommand() error {
 	}
 	password := sys.InputPassword(true, "", "Enter key server's password (no echo)")
 	// Test the connection and password
-	salt, err := client.GetSalt()
-	if err != nil {
-		return err
-	}
-	if err := client.Ping(keyserv.PingRequest{Password: keyserv.HashPassword(salt, password)}); err != nil {
+	if err := client.Ping(keyserv.PingRequest{PlainPassword: password}); err != nil {
 		return err
 	}
 	// Interactively gather pending command details
@@ -555,7 +547,7 @@ func SendCommand() error {
 		return fmt.Errorf("Failed to update database record - %v", err)
 	}
 	// Ask server to reload the record from disk
-	client.ReloadRecord(keyserv.ReloadRecordReq{Password: keyserv.HashPassword(salt, password), UUID: uuid})
+	client.ReloadRecord(keyserv.ReloadRecordReq{PlainPassword: password, UUID: uuid})
 	fmt.Printf("All done! Computer %s will be informed of the command when it comes online and polls from this server.\n", ip)
 	return nil
 }
@@ -569,11 +561,7 @@ func ClearPendingCommands() error {
 	}
 	password := sys.InputPassword(true, "", "Enter key server's password (no echo)")
 	// Test the connection and password
-	salt, err := client.GetSalt()
-	if err != nil {
-		return err
-	}
-	if err := client.Ping(keyserv.PingRequest{Password: keyserv.HashPassword(salt, password)}); err != nil {
+	if err := client.Ping(keyserv.PingRequest{PlainPassword: password}); err != nil {
 		return err
 	}
 	uuid := sys.Input(true, "", "What is the UUID of disk to be cleared of pending commands?")
@@ -587,7 +575,7 @@ func ClearPendingCommands() error {
 		return fmt.Errorf("Failed to update database record - %v", err)
 	}
 	// Ask server to reload the record from disk
-	client.ReloadRecord(keyserv.ReloadRecordReq{Password: keyserv.HashPassword(salt, password), UUID: uuid})
+	client.ReloadRecord(keyserv.ReloadRecordReq{PlainPassword: password, UUID: uuid})
 	fmt.Printf("All of %s's pending commands have been successfully cleared.\n", uuid)
 	return nil
 }

--- a/keyserv/rpc_client.go
+++ b/keyserv/rpc_client.go
@@ -250,7 +250,7 @@ func StartTestServer(tb testing.TB) (*CryptClient, *CryptServer, func(testing.TB
 	// Server should start within about 2 seconds
 	serverReady := false
 	for i := 0; i < 20; i++ {
-		if err := client.Ping(PingRequest{Password: HashPassword(salt, TEST_RPC_PASS)}); err == nil {
+		if err := client.Ping(PingRequest{PlainPassword: TEST_RPC_PASS}); err == nil {
 			serverReady = true
 			break
 		}
@@ -265,7 +265,7 @@ func StartTestServer(tb testing.TB) (*CryptClient, *CryptServer, func(testing.TB
 			t.Fatal(err)
 			return
 		}
-		if err := client.Ping(PingRequest{Password: HashPassword(salt, TEST_RPC_PASS)}); err == nil {
+		if err := client.Ping(PingRequest{PlainPassword: TEST_RPC_PASS}); err == nil {
 			t.Fatal("server did not shutdown")
 			return
 		}

--- a/keyserv/rpc_client_bench_test.go
+++ b/keyserv/rpc_client_bench_test.go
@@ -21,7 +21,7 @@ func BenchmarkSaveKey(b *testing.B) {
 	// The benchmark will run all RPC operations consecutively
 	for i := 0; i < b.N; i++ {
 		if _, err := client.CreateKey(CreateKeyReq{
-			Password:         HashPassword(salt, TEST_RPC_PASS),
+			PlainPassword:    TEST_RPC_PASS,
 			Hostname:         "localhost",
 			UUID:             "aaa",
 			MountPoint:       "/a",
@@ -49,7 +49,7 @@ func BenchmarkAutoRetrieveKey(b *testing.B) {
 	defer runtime.GOMAXPROCS(oldMaxprocs)
 	runtime.GOMAXPROCS(1)
 	if _, err := client.CreateKey(CreateKeyReq{
-		Password:         HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		Hostname:         "localhost",
 		UUID:             "aaa",
 		MountPoint:       "/a",
@@ -86,7 +86,7 @@ func BenchmarkManualRetrieveKey(b *testing.B) {
 	defer runtime.GOMAXPROCS(oldMaxprocs)
 	runtime.GOMAXPROCS(1)
 	if _, err := client.CreateKey(CreateKeyReq{
-		Password:         HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		Hostname:         "localhost",
 		UUID:             "aaa",
 		MountPoint:       "/a",
@@ -101,7 +101,7 @@ func BenchmarkManualRetrieveKey(b *testing.B) {
 	// The benchmark will run all RPC operations consecutively
 	for i := 0; i < b.N; i++ {
 		if resp, err := client.ManualRetrieveKey(ManualRetrieveKeyReq{
-			Password: HashPassword(salt, TEST_RPC_PASS),
+			PlainPassword:    TEST_RPC_PASS,
 			UUIDs:    []string{"aaa"},
 			Hostname: "localhost",
 		}); err != nil || len(resp.Granted) != 1 {
@@ -124,7 +124,7 @@ func BenchmarkReportAlive(b *testing.B) {
 	defer runtime.GOMAXPROCS(oldMaxprocs)
 	runtime.GOMAXPROCS(1)
 	if _, err := client.CreateKey(CreateKeyReq{
-		Password:         HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		Hostname:         "localhost",
 		UUID:             "aaa",
 		MountPoint:       "/a",
@@ -137,7 +137,7 @@ func BenchmarkReportAlive(b *testing.B) {
 	}
 	// Retrieve the key so that this computer becomes eligible to send alive messages
 	if resp, err := client.ManualRetrieveKey(ManualRetrieveKeyReq{
-		Password: HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		UUIDs:    []string{"aaa"},
 		Hostname: "localhost",
 	}); err != nil || len(resp.Granted) != 1 {

--- a/keyserv/rpc_client_test.go
+++ b/keyserv/rpc_client_test.go
@@ -36,15 +36,10 @@ func TestCreateKeyReq_Validate(t *testing.T) {
 func TestRPCCalls(t *testing.T) {
 	client, _, tearDown := StartTestServer(t)
 	defer tearDown(t)
-	// Retrieve server's password salt
-	salt, err := client.GetSalt()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := client.Ping(PingRequest{Password: HashPassword(salt, "wrong password")}); err == nil {
+	if err := client.Ping(PingRequest{PlainPassword: "wrong password")); err == nil {
 		t.Fatal("did not error")
 	}
-	if err := client.Ping(PingRequest{Password: HashPassword(salt, TEST_RPC_PASS)}); err != nil {
+	if err := client.Ping(PingRequest{PlainPassword: TEST_RPC_PASS}); err != nil {
 		t.Fatal(err)
 	}
 	// Construct a client via sysconfig
@@ -56,12 +51,12 @@ func TestRPCCalls(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := scClient.Ping(PingRequest{Password: HashPassword(salt, TEST_RPC_PASS)}); err != nil {
+	if err := scClient.Ping(PingRequest{PlainPassword: TEST_RPC_PASS}); err != nil {
 		t.Fatal(err)
 	}
 	// Refuse to save a key if password is incorrect
 	createResp, err := client.CreateKey(CreateKeyReq{
-		Password:         HashPassword(salt, "wrong password"),
+		PlainPassword:    "wrong password",
 		Hostname:         "localhost",
 		UUID:             "aaa",
 		MountPoint:       "/a",
@@ -75,7 +70,7 @@ func TestRPCCalls(t *testing.T) {
 	}
 	// Save two good keys
 	createResp, err = client.CreateKey(CreateKeyReq{
-		Password:         HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		Hostname:         "localhost",
 		UUID:             "aaa",
 		MountPoint:       "/a",
@@ -88,7 +83,7 @@ func TestRPCCalls(t *testing.T) {
 		t.Fatal(err)
 	}
 	createResp, err = client.CreateKey(CreateKeyReq{
-		Password:         HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		Hostname:         "localhost",
 		UUID:             "bbb",
 		MountPoint:       "/b",
@@ -158,14 +153,14 @@ func TestRPCCalls(t *testing.T) {
 
 	// Forcibly retrieve both keys and verify
 	if _, err := client.ManualRetrieveKey(ManualRetrieveKeyReq{
-		Password: HashPassword(salt, "wrong password"),
+		PlainPassword:    "wrong password",
 		UUIDs:    []string{"aaa"},
 		Hostname: "localhost",
 	}); err == nil {
 		t.Fatal("did not error")
 	}
 	manResp, err := client.ManualRetrieveKey(ManualRetrieveKeyReq{
-		Password: HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		UUIDs:    []string{"aaa", "bbb", "does_not_exist"},
 		Hostname: "localhost",
 	})
@@ -191,7 +186,7 @@ func TestRPCCalls(t *testing.T) {
 
 	// Delete key
 	if err := client.EraseKey(EraseKeyReq{
-		Password: HashPassword(salt, "wrong password"),
+		PlainPassword:    "wrong password",
 		Hostname: "localhost",
 		UUID:     "aaa",
 	}); err == nil {
@@ -199,14 +194,14 @@ func TestRPCCalls(t *testing.T) {
 	}
 	// Erasing a non-existent key should not result in an error
 	if err := client.EraseKey(EraseKeyReq{
-		Password: HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		Hostname: "localhost",
 		UUID:     "doesnotexist",
 	}); err != nil {
 		t.Fatal(err)
 	}
 	if err := client.EraseKey(EraseKeyReq{
-		Password: HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		Hostname: "localhost",
 		UUID:     "aaa",
 	}); err != nil {
@@ -214,7 +209,7 @@ func TestRPCCalls(t *testing.T) {
 	}
 	// Erasing a non-existent key should not result in an error
 	if err := client.EraseKey(EraseKeyReq{
-		Password: HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		Hostname: "localhost",
 		UUID:     "aaa",
 	}); err != nil {
@@ -227,12 +222,8 @@ func TestPendingCommands(t *testing.T) {
 	client, server, tearDown := StartTestServer(t)
 	defer tearDown(t)
 	// Create a key that will host pending commands
-	salt, err := client.GetSalt()
-	if err != nil {
-		t.Fatal(err)
-	}
 	client.CreateKey(CreateKeyReq{
-		Password:         HashPassword(salt, TEST_RPC_PASS),
+		PlainPassword:    TEST_RPC_PASS,
 		Hostname:         "localhost",
 		UUID:             "a-a-a-a",
 		MountPoint:       "/",

--- a/keyserv/rpc_svc.go
+++ b/keyserv/rpc_svc.go
@@ -427,6 +427,8 @@ func (rpcConn *CryptServiceConn) Ping(req PingRequest, _ *DummyAttr) error {
 		if err := rpcConn.Svc.ValidatePassword(req.Password); err != nil {
 			return err
 		}
+	} else {
+		return errors.New("No valid authentication method.")
 	}
 	if err := rpcConn.Svc.CheckInitialSetup(); err != nil {
 		return fmt.Errorf("Ping: the server is not ready to manage encryption keys - %v", err)

--- a/ospackage/etc/sysconfig/cryptctl-server
+++ b/ospackage/etc/sysconfig/cryptctl-server
@@ -167,3 +167,10 @@ KMIP_TLS_CERT_KEY_PEM=""
 # If set to "no", cryptctl server will reduce its security measures by not verifying KMIP server's TLS certificate.
 # Remember to restart cryptctl-server.service after changing any value of this file.
 KMIP_TLS_DO_VERIFY="yes"
+
+## Type:    boolean
+## Default: "no"
+#
+# For security reason it is not recommended to allow hashed password authentication.
+# For compatibility reasen this can be set yes until all clients are updated
+HASH_AUTH="no"

--- a/ospackage/etc/sysconfig/cryptctl-server
+++ b/ospackage/etc/sysconfig/cryptctl-server
@@ -173,4 +173,4 @@ KMIP_TLS_DO_VERIFY="yes"
 #
 # For security reason it is not recommended to allow hashed password authentication.
 # For compatibility reasen this can be set yes until all clients are updated
-HASH_AUTH="no"
+ALLOW_HASH_AUTH="no"

--- a/routine/encrypt.go
+++ b/routine/encrypt.go
@@ -186,12 +186,8 @@ func EncryptFS(progressOut io.Writer, client *keyserv.CryptClient,
 		return "", fmt.Errorf(MSG_E_SRC_DIR_MOUNT_NOT_FOUND, srcDir)
 	}
 	cryptDevUUID := MakeUUID()
-	salt, err := client.GetSalt()
-	if err != nil {
-		return "", fmt.Errorf(MSG_E_RPC_KEY_CREATE, err)
-	}
 	encryptionKeyResp, err := client.CreateKey(keyserv.CreateKeyReq{
-		Password:         keyserv.HashPassword(salt, password),
+		PlainPassword:    password,
 		UUID:             cryptDevUUID,
 		MountPoint:       srcDir,
 		MountOptions:     srcDirMount.Options,

--- a/routine/unlock.go
+++ b/routine/unlock.go
@@ -37,14 +37,10 @@ func ManOnlineUnlockFS(progressOut io.Writer, client *keyserv.CryptClient, passw
 		return errors.New("Cannot find any more encrypted file systems.")
 	}
 	hostname, _ := sys.GetHostnameAndIP()
-	salt, err := client.GetSalt()
-	if err != nil {
-		return err
-	}
 	resp, err := client.ManualRetrieveKey(keyserv.ManualRetrieveKeyReq{
 		UUIDs:    reqUUIDs,
 		Hostname: hostname,
-		Password: keyserv.HashPassword(salt, password),
+		PlainPassword: password,
 	})
 	if err != nil {
 		return err
@@ -265,11 +261,10 @@ func EraseKey(progressOut io.Writer, client *keyserv.CryptClient, password, uuid
 	}
 	// After metadata is erased, ask server to remove its key record as well.
 	hostname, _ := sys.GetHostnameAndIP()
-	salt, err := client.GetSalt()
-	if err != nil {
-		return err
-	}
-	if err := client.EraseKey(keyserv.EraseKeyReq{Password: keyserv.HashPassword(salt, password), Hostname: hostname, UUID: uuid}); err != nil {
+	if err := client.EraseKey(keyserv.EraseKeyReq{
+		PlainPassword: password,
+		Hostname: hostname,
+		UUID: uuid}); err != nil {
 		return err
 	}
 	fmt.Fprintf(progressOut, "Encryption header has been wiped successfully, data in \"%s\" (%s) is now irreversibly lost.\n",


### PR DESCRIPTION
The client should authenticate with plain text password instead of the salted password hash.
For compatibility reason the server can handle authentication with  hashed passwords too if this is allowed by the sysconfig variable ALLOW_HASH_AUTH.
The types PingRequest, ManualRetrieveKeyReq, CreateKeyReq, EraseKeyReq, ReloadRecordReq got a new string attribute PlainPassword.
Supported update:
Step 1. Update the server
Step 2. Set ALLOW_HASH_AUTH to yes if the update of the Clients can take a long time and some password authentication issue can happend.
Step 3. Update the clients
Step 4. Set ALLOW_HASH_AUTH to no.